### PR TITLE
Single setup call to fix sdist/wheel creation from pypi.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [devpi:upload]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ meta = dict(
 try:
     load_entry_point(meta['name'], ENTRY_GROUP, ENTRY_NAME)
 except (DistributionNotFound, ImportError):
-    setup(version='0', **meta)
     working_set.add_entry('.')
 
 setup(use_scm_version=True, **meta)


### PR DESCRIPTION
Make a single call to "setup" and change wheel to bdist_wheel in setup.cfg given the newer standards.

This PR is related to issue #9, because of the double setup calls, my current guess is some race condition between the removal/creation of the build directories between the two setup call, sometimes it works.

I already upload the package [under my username in pypi](https://pypi.org/project/cyraxjoe-setuptools-scm-git-archive/#files) but it would be nice to have 1.0.1 with this changes. 