### PR TITLE
Provide config arg to quiet warning from meta()

### DIFF
--- a/setuptools_scm_git_archive/__init__.py
+++ b/setuptools_scm_git_archive/__init__.py
@@ -1,18 +1,22 @@
 from os.path import join
 import re
 
+from setuptools_scm import Configuration
 from setuptools_scm.utils import data_from_mime, trace
 from setuptools_scm.version import meta, tags_to_versions
 
 
 tag_re = re.compile(r'(?<=\btag: )([^,]+)\b')
 
+# Define default config so call to meta() does not warn
+config = Configuration()
+
 
 def archival_to_version(data):
     trace('data', data)
     versions = tags_to_versions(tag_re.findall(data.get('ref-names', '')))
     if versions:
-        return meta(versions[0])
+        return meta(versions[0], config=config)
 
 
 def parse(root):


### PR DESCRIPTION
The call to `setuptools_scm.version.meta()` is made here without providing an arg value for `config`, which always generates a warning from this code:

https://github.com/pypa/setuptools_scm/blob/7b21089a545667f0ae7852e1039f8028be288f48/src/setuptools_scm/version.py#L198

Example for a package downloaded from GitHub as a release zipfile:
```
(install-test37) ➜  proseco-4.8.0 python setup.py --version
/Users/aldcroft/Downloads/proseco-4.8.0/.eggs/setuptools_scm-3.5.0-py3.7.egg/setuptools_scm/version.py:200: UserWarning: meta invoked without explicit configuration, will use defaults where required.
  "meta invoked without explicit configuration,"
4.8.0
```

This warning is confusing and makes users wonder if there is a real problem that needs attention, e.g. #8.