### PR TITLE
Include unannotated tags in migration guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ to::
 
     node: $Format:%H$
     node-date: $Format:%cI$
-    describe-name: $Format:%(describe)$
+    describe-name: $Format:%(describe:tags=true)$
     ref-names: $Format:%D$
 
 Remove ``setuptools_scm_git_archive`` from your project's dependencies (e.g. the


### PR DESCRIPTION
adding the tags option to the describe substitution better mimics the `setuptools_scm_git_archive` behavior when a repo uses unannotated tags