### PR TITLE
Set upper bound to setuptools-scm to avoid downstream failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ meta = dict(
     packages=find_packages(),
     long_description=open(join(dirname(__file__), 'README.rst')).read(),
     keywords='scm vcs version tags git archive',
-    setup_requires=['setuptools-scm'],
+    setup_requires=['setuptools-scm<8'],
     entry_points={
         ENTRY_GROUP: ENTRY_POINT,
         ENTRY_GROUP_FALLBACK: ENTRY_POINT,


### PR DESCRIPTION
Projects that still depend on this package or depend on other packages that depend on this are now breaking because of setuptools_scm 8.0 making changes that are incompatible. By making this change and making a new release it would buy these projects more time to make updates to their build process.

See https://github.com/pypa/setuptools_scm/issues/914