### PR TITLE
Compat with python-setuptools_scm > 8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ meta = dict(
     packages=find_packages(),
     long_description=open(join(dirname(__file__), 'README.rst')).read(),
     keywords='scm vcs version tags git archive',
-    setup_requires=['setuptools-scm<8'],
+    setup_requires=['setuptools-scm'],
     entry_points={
         ENTRY_GROUP: ENTRY_POINT,
         ENTRY_GROUP_FALLBACK: ENTRY_POINT,

--- a/setuptools_scm_git_archive/__init__.py
+++ b/setuptools_scm_git_archive/__init__.py
@@ -3,8 +3,9 @@ import re
 import warnings
 
 from setuptools_scm import Configuration
-from setuptools_scm.utils import data_from_mime, trace
-from setuptools_scm.version import meta, tags_to_versions
+from setuptools_scm.integration import data_from_mime
+from setuptools_scm.version import meta, tag_to_version
+from setuptools_scm.git import archival_to_version
 
 
 warnings.warn(DeprecationWarning(
@@ -12,20 +13,11 @@ warnings.warn(DeprecationWarning(
 ))
 
 
-tag_re = re.compile(r'(?<=\btag: )([^,]+)\b')
-
-# Define default config so call to meta() does not warn
 config = Configuration()
 
-
-def archival_to_version(data):
-    trace('data', data)
-    versions = tags_to_versions(tag_re.findall(data.get('ref-names', '')))
-    if versions:
-        return meta(versions[0], config=config)
 
 
 def parse(root):
     archival = join(root, '.git_archival.txt')
     data = data_from_mime(archival)
-    return archival_to_version(data)
+    return archival_to_version(data, config)

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 import pytest
-from setuptools_scm import format_version
+from setuptools_scm.version import format_version
 from setuptools_scm_git_archive import archival_to_version
+from setuptools_scm import Configuration
 
 
 git_archival_mapping = {
@@ -12,8 +13,9 @@ git_archival_mapping = {
 
 @pytest.mark.parametrize('expected,data', sorted(git_archival_mapping.items()))
 def test_archival_to_version(expected, data):
-    version = archival_to_version(data)
-    assert format_version(
-        version,
-        version_scheme='guess-next-dev',
-        local_scheme='node-and-date') == expected
+    config = Configuration(
+        version_scheme="guess-next-dev", local_scheme="node-and-date"
+    )
+    version = archival_to_version(data, config=config)
+    assert version is not None
+    assert format_version(version) == expected


### PR DESCRIPTION
Use funs in python-setuptools_scm, for temporary compatibility.